### PR TITLE
Removing library id resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ have a layout which the recycler view is part of.
 **Examples:**
 
 ```kotlin
-val recycler = Recycler.create<ItemType>(context) {
+val recycler = Recycler.create<ItemType>(context, id = R.id.myrecycler) {
   ...
 }
 ```

--- a/lib/src/main/kotlin/com/squareup/cycler/Recycler.kt
+++ b/lib/src/main/kotlin/com/squareup/cycler/Recycler.kt
@@ -567,16 +567,22 @@ class Recycler<I : Any> internal constructor(
   companion object {
     /**
      * Factory method to create a Recycler.
-     * The [block] is a lambda on [Recycler.Config] specifying all row types
-     * and extra options.
+     * The [block] is a lambda on
+     * @param context context to create the [RecyclerView].
+     * @param id id for the [RecyclerView]. Defaults to [View.NO_ID].
+     * @param layoutProvider lambda generating a [RecyclerView.LayoutManager] for the view. If not
+     * provided a [LinearLayoutManager] will be provided.
+     * @param block this is the lambda on [Recycler.Config] specifying all the content configuration.
+     *
      */
     inline fun <I : Any> create(
       context: Context,
+      id: Int = View.NO_ID,
       layoutProvider: (Context) -> LayoutManager = { LinearLayoutManager(it) },
       crossinline block: Config<I>.() -> Unit
     ): Recycler<I> {
       val view = RecyclerView(context)
-      view.id = R.id.recyclerView
+      view.id = id
       view.layoutManager = layoutProvider(context)
       return adopt(view, block)
     }
@@ -591,10 +597,6 @@ class Recycler<I : Any> internal constructor(
       crossinline block: Config<I>.() -> Unit
     ): Recycler<I> {
       requireNotNull(view.layoutManager) { "RecyclerView needs a layoutManager assigned." }
-      // Check this recycler wasn't adopted before.
-      require(view.getTag(R.id.recycler_adopted) == null) { "RecyclerView is already adopted." }
-      view.setTag(R.id.recycler_adopted, true)
-
       return Config<I>()
           .apply(block)
           .setUp(view)

--- a/lib/src/main/res/values/ids.xml
+++ b/lib/src/main/res/values/ids.xml
@@ -1,9 +1,0 @@
-<?xml version="1.0" encoding="utf-8"?>
-<resources>
-  <!--
-  This ID is applied to every RecyclerView when using the DSL to create one. This allows
-  view state restoration to work and makes finding the view in instrumentation tests easier.
-  -->
-  <item type="id" name="recyclerView"/>
-  <item type="id" name="recycler_adopted"/>
-</resources>


### PR DESCRIPTION
Allows other AAR libraries –like Square Reader SDK– to include `com.squareup.cycler` internally without the need to declare it as external dependency, therefore, not forcing applications to depend on a particular version of this library.