### PR TITLE
Swipe: allow swipe drawing customization

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,9 +13,13 @@ buildscript {
     app_compat: 'androidx.appcompat:appcompat:1.1.0',
     coroutines_android: "org.jetbrains.kotlinx:kotlinx-coroutines-android:${coroutines_version}",
     coroutines_core: "org.jetbrains.kotlinx:kotlinx-coroutines-core:${coroutines_version}",
+    junit: 'junit:junit:4.13',
     kotlin_stdlib: "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${kotlin_version}",
     maven_publish: "com.vanniktech:gradle-maven-publish-plugin:0.8.0",
+    mockito: 'org.mockito:mockito-core:2.28.2',
+    mockito_kotlin: 'com.nhaarman.mockitokotlin2:mockito-kotlin:2.2.0',
     recyclerview: 'androidx.recyclerview:recyclerview:1.1.0',
+    robolectric: 'org.robolectric:robolectric:4.3',
     truth: 'com.google.truth:truth:1.0',
   ]
 

--- a/lib/build.gradle
+++ b/lib/build.gradle
@@ -18,7 +18,11 @@ dependencies {
   implementation deps.coroutines_android
   implementation deps.coroutines_core
 
+  testImplementation deps.junit
+  testImplementation deps.mockito
+  testImplementation deps.mockito_kotlin
   testImplementation deps.truth
+  testImplementation deps.robolectric
 }
 
 mavenPublishAs(

--- a/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
@@ -1,23 +1,61 @@
 package com.squareup.cycler
 
+import android.graphics.Canvas
 import android.view.MotionEvent
 import android.view.View
+import android.view.View.MeasureSpec
+import androidx.annotation.VisibleForTesting
 import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.RecyclerView
 import androidx.recyclerview.widget.RecyclerView.ViewHolder
+import com.squareup.cycler.Recycler.CreatorContext
+import com.squareup.cycler.Recycler.RowSpec
 import com.squareup.cycler.StandardRowSpec.Creator
+import com.squareup.cycler.SwipeDirection.Companion.BOTH
+import com.squareup.cycler.SwipeDirection.Companion.NONE
+import com.squareup.cycler.SwipeDirection.END
+import com.squareup.cycler.SwipeDirection.LEFT
+import com.squareup.cycler.SwipeDirection.RIGHT
+import com.squareup.cycler.SwipeDirection.START
+import java.lang.IllegalStateException
+import java.util.EnumSet
+import kotlin.math.abs
 
 fun <I : Any> Recycler.Config<I>.enableMutations(block: MutationExtensionSpec<I>.() -> Unit) {
   extension(MutationExtensionSpec<I>().apply(block))
 }
 
+/**
+ * Used in swipe related methods. They can be absolute or text-direction relative ([START]/[END]).
+ * The values used will depend on what is returned in [MutationExtensionSpec.canSwipe].
+ */
+enum class SwipeDirection(val absolute: Boolean, val platformValue: Int) {
+  START(false, ItemTouchHelper.START),
+  END(false, ItemTouchHelper.END),
+  LEFT(true, ItemTouchHelper.LEFT),
+  RIGHT(true, ItemTouchHelper.RIGHT);
+
+  companion object {
+    val NONE: Set<SwipeDirection> = EnumSet.noneOf(SwipeDirection::class.java)
+    val BOTH: Set<SwipeDirection> = EnumSet.of(START, END)
+    val BOTH_ABSOLUTE: Set<SwipeDirection> = EnumSet.of(LEFT, RIGHT)
+  }
+}
+
 class MutationExtensionSpec<T : Any> : ExtensionSpec<T> {
   override fun create(): Extension<T> = MutationExtension(this)
   internal var onMove: ((Int, Int) -> Unit)? = null
-  internal var onSwipeToRemove: ((T) -> Unit)? = null
-  internal var canSwipeToRemoveItem: ((T) -> Boolean) = { true }
+  internal var onSwiped: ((T, direction: SwipeDirection) -> Unit)? = null
+  internal var canSwipeItem: ((T) -> Set<SwipeDirection>) = {
+    // It defaults to the behavior it had before this property existed:
+    // swipeToRemoveEnabled means both sides. Otherwise it won't swipe either way.
+    if (swipeToRemoveEnabled) BOTH else NONE
+  }
   internal var canDropOverItem: ((T) -> Boolean) = { true }
   internal var onDragDrop: ((originalIndex: Int, dropIndex: Int) -> Unit)? = null
+
+  @PublishedApi
+  internal val swipeUnderViewSpecs = mutableListOf<RowSpec<Any, SwipeBindData<*>, View>>()
 
   /**
    * Determine whether items can be swiped left to right or right to left to remove them from the
@@ -43,19 +81,72 @@ class MutationExtensionSpec<T : Any> : ExtensionSpec<T> {
   }
 
   /**
-   * Register a callback that will be invoked when an item is removed by swiping it
+   * Allows to define a [RowSpec] (usual `create/bind` mechanism) for a view that will be drawn
+   * below a swiped row. It's created when the swipe is initiated and bind is called with every
+   * movement receiving [SwipeBindData] so:
+   *
+   * - the original swiped view can be retouched accorindg to the percentage (alpha for instance)
+   * - the original dataItem, in case its data is needed for the underview, and the underview itself.
+   *
+   * WARNING: this API might evolve as currently:
+   *
+   * - under view is only defined at top level, and cannot be customized for each row-type,
+   *   which should be the case using Cycler.
+   * - probably there should be extra callbacks or customizations available for swiping. For
+   *   instance: to restore the original alpha of the swiped view.
    */
-  fun onSwipeToRemove(block: (T) -> Unit) {
-    onSwipeToRemove = block
+  inline fun <reified S : T, V : View> swipeUnderViewSpec(
+    block: StandardRowSpec<Any, SwipeBindData<S>, V>.() -> Unit
+  ) {
+    // RowSpec's super type is Any. We cannot use the proper T
+    // because we are not passing the proper S, but SwipeBindData<...>.
+    swipeUnderViewSpecs += StandardRowSpec<Any, SwipeBindData<S>, V> { it is S }.apply(block)
+  }
+
+  @Deprecated("Use onSwiped", ReplaceWith("onSwiped(block)"))
+  inline fun onSwipeToRemove(crossinline block: (T) -> Unit) {
+    onSwiped { item: T, _: SwipeDirection -> block(item) }
   }
 
   /**
-   * Register a check that will be invoked for each item to decide whether that item can be swiped to
-   * remove it or not. This allows a hook for recyclers to specify which items do and do not support
-   * swipe to remove.
+   * Register a callback that will be invoked when an item is removed by swiping it.
    */
-  fun canSwipeToRemoveItem(block: (T) -> Boolean) {
-    canSwipeToRemoveItem = block
+  inline fun onSwiped(crossinline block: (T) -> Unit) {
+    onSwiped { item: T, _: SwipeDirection -> block(item) }
+  }
+
+  @Deprecated("Use onSwiped", ReplaceWith("onSwiped(block)"))
+  fun onSwipeToRemove(block: (T, direction: SwipeDirection) -> Unit) {
+    onSwiped(block)
+  }
+
+  /**
+   * Register a callback that will be invoked when an item is removed by swiping it.
+   * @param block receives the swiped data item and the direction.
+   * @see SwipeDirection
+   */
+  fun onSwiped(block: (T, direction: SwipeDirection) -> Unit) {
+    onSwiped = block
+  }
+
+  @Deprecated(
+    message = "Use the version that specifies which side is allowed.",
+    replaceWith = ReplaceWith(
+      expression = "canSwipe { if (block(it)) SwipeDirection.BOTH else SwipeDirection.NONE }"
+    )
+  )
+  inline fun canSwipeToRemoveItem(crossinline block: (T) -> Boolean) {
+    canSwipe { if (block(it)) SwipeDirection.BOTH else SwipeDirection.NONE }
+  }
+
+  /**
+   * Register a check that will be invoked for each item to decide whether that item can be swiped
+   * or not. This should return which directions are allowed.
+   *
+   * See the other version of the method, that returns which direction is allowed.
+   */
+  fun canSwipe(block: (T) -> Set<SwipeDirection>) {
+    canSwipeItem = block
   }
 
   /**
@@ -94,8 +185,7 @@ fun <I : Any> Recycler<I>.getMutatedData(): DataSource<I> {
   return data.let { source ->
     mutableListOf<I>().apply {
       addAll((0 until source.size).asSequence().map(source::get))
-    }
-        .toDataSource()
+    }.toDataSource()
   }
 }
 
@@ -109,6 +199,93 @@ fun <I : Any, S : I, V : View> Creator<I, S, V>.dragHandle(view: View) {
   requireNotNull(creatorContext.extension<MutationExtension<I>>()) {
     "Drag and drop extension was not configured for the Recycler."
   }.setUpDragHandle(view)
+}
+
+private class SwipeState<T : Any, V : View>(
+  val viewHolder: Recycler.ViewHolder<V>,
+  var bindData: SwipeBindData<T>
+) {
+
+  /**
+   * @return true if the binding was successful. It is, the under-view should be painted.
+   */
+  fun bind(viewTranslation: Float): Boolean {
+    val valid = bindData.bind(viewTranslation)
+    if (valid) {
+      viewHolder.bind(0, bindData)
+    }
+    return valid
+  }
+}
+
+/**
+ * Passed as data for the [RowSpec.bind] defined in [MutationExtensionSpec.swipeUnderViewSpec].
+ */
+class SwipeBindData<T : Any>
+@VisibleForTesting
+internal constructor(
+  val dataItem: T,
+  val swipedView: View,
+  private val allowedDirections: Set<SwipeDirection>
+) {
+
+  private val rightToLeft = swipedView.layoutDirection == View.LAYOUT_DIRECTION_RTL
+
+  /**
+   * It will tell if the [bind] was called successfully and there's a [direction] and [percentage]
+   * to provide to the developer's handler.
+   */
+  internal var isValid = false
+
+  /**
+   * The direction the swipe is happening at the moment.
+   * If both directions are allowed this might change for the same swipe.
+   */
+  lateinit var direction: SwipeDirection
+    internal set
+
+  /**
+   * Represents the percentage of swiping to the size. 0f <= percentage <= 1f.
+   * - 0f means the view is exactly in its normal place.
+   * - 1f means the view is completely swiped to the [direction].
+   */
+  var percentage: Float = 0f
+    internal set
+
+  /**
+   * @return true if the binding was successful: valid direction and percentage.
+   */
+  fun bind(viewTranslation: Float): Boolean {
+    isValid = doBind(viewTranslation)
+    return isValid
+  }
+
+  private fun doBind(viewTranslation: Float): Boolean {
+    val viewWidth = swipedView.width
+    if (viewWidth <= 0) {
+      return false
+    }
+    val swipingLeft = viewTranslation < 0
+    val candidateDirections = when {
+      swipingLeft && !rightToLeft -> leftDirections
+      !swipingLeft && !rightToLeft -> rightDirections
+      swipingLeft && rightToLeft -> leftDirectionsRtl
+      !swipingLeft && rightToLeft -> rightDirectionsRtl
+      else -> throw IllegalStateException("Unreachable code")
+    }
+    direction = candidateDirections
+        .firstOrNull(allowedDirections::contains)
+        ?: return false // This should not happen (but if it does, don't crash).
+    percentage = abs(viewTranslation / viewWidth).coerceAtMost(1f)
+    return true
+  }
+
+  companion object {
+    val leftDirections = listOf(START, LEFT)
+    val rightDirections = listOf(END, RIGHT)
+    val leftDirectionsRtl = listOf(END, LEFT)
+    val rightDirectionsRtl = listOf(START, RIGHT)
+  }
 }
 
 private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : Extension<T> {
@@ -140,6 +317,7 @@ private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : E
     private var lastActionState = ItemTouchHelper.ACTION_STATE_IDLE
     private var draggedItemOriginalIndex = -1
     private var draggedItemCurrentIndex = -1
+    private var swipeState: SwipeState<*, *>? = null
 
     override fun getMovementFlags(
       recyclerView: RecyclerView,
@@ -164,11 +342,11 @@ private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : E
         data.forPosition(
             viewHolder.adapterPosition,
             onDataItem = {
-              if (spec.canSwipeToRemoveItem(it)) {
-                ItemTouchHelper.START or ItemTouchHelper.END
-              } else {
-                0
+              val directions = spec.canSwipeItem(it)
+              if (directions.isNotEmpty()) {
+                createSwipeStateFor(it, viewHolder.itemView, directions)
               }
+              directions.toPlatformValue()
             },
             onExtraItem = { 0 },
             orElse = { 0 }
@@ -258,10 +436,74 @@ private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : E
       lastActionState = actionState
     }
 
+    private fun removeSwipeState() {
+      swipeState = null
+    }
+
+    private fun createSwipeStateFor(
+      dataItem: T,
+      itemView: View,
+      allowedDirections: Set<SwipeDirection>
+    ) {
+      // TODO (https://github.com/square/cycler/issues/14): custom underView specs for rows.
+      val underViewRowSpec = spec.swipeUnderViewSpecs.firstOrNull { it.matches(dataItem) }
+      underViewRowSpec?.createViewHolder(
+          CreatorContext(recycler),
+          subType = 0
+      )?.let { holder ->
+        val underView = holder.itemView
+        underView.measure(
+            MeasureSpec.makeMeasureSpec(itemView.width, MeasureSpec.EXACTLY),
+            MeasureSpec.makeMeasureSpec(itemView.height, MeasureSpec.EXACTLY)
+        )
+        underView.layout(0, 0, itemView.width, itemView.height)
+        swipeState = SwipeState(holder, SwipeBindData(dataItem, itemView, allowedDirections))
+      }
+    }
+
+    /**
+     * This customizes drawing for swiping by drawing below the dragged view.
+     * We still call the standard method even for swiping as we want any standard processing
+     * (like translucency) to be applied.
+     */
+    override fun onChildDraw(
+      canvas: Canvas,
+      recyclerView: RecyclerView,
+      viewHolder: ViewHolder,
+      dX: Float,
+      dY: Float,
+      actionState: Int,
+      isCurrentlyActive: Boolean
+    ) {
+      if (actionState == ItemTouchHelper.ACTION_STATE_SWIPE) {
+        data.forPosition(
+            viewHolder.adapterPosition,
+            onDataItem = { _ ->
+              swipeState?.let { state ->
+                if (state.bind(dX)) {
+                  val count = canvas.save()
+                  canvas.translate(
+                      viewHolder.itemView.left.toFloat(),
+                      viewHolder.itemView.top.toFloat()
+                  )
+                  val underView = state.viewHolder.itemView
+                  underView.draw(canvas)
+                  canvas.restoreToCount(count)
+                }
+              }
+            },
+            onExtraItem = { 0 },
+            orElse = { 0 }
+        )
+      }
+      super.onChildDraw(canvas, recyclerView, viewHolder, dX, dY, actionState, isCurrentlyActive)
+    }
+
     override fun onSwiped(
       viewHolder: RecyclerView.ViewHolder,
       direction: Int
     ) {
+      removeSwipeState()
       if (data.frozen) {
         // If the data has been frozen (undergoing update) we cannot swap / drag anymore!
         // See [RecyclerData.frozen] for an explanation.
@@ -273,7 +515,18 @@ private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : E
       data.remove(position)
       recycler.view.adapter!!.notifyItemRemoved(position)
       // Tell the callback.
-      spec.onSwipeToRemove?.invoke(dataItem)
+      spec.onSwiped?.invoke(dataItem, direction.toSwipeDirection())
     }
   }
 }
+
+private fun Set<SwipeDirection>.toPlatformValue() = fold(0) { acc, direction ->
+  acc or direction.platformValue
+}
+
+/**
+ * We use this conversion only when we get notified from the Recycler.
+ * That notification only uses values approved by us previously, and those values come from
+ * [SwipeDirection]. Therefore, the value *must* be one of them.
+ */
+private fun Int.toSwipeDirection() = SwipeDirection.values().first { it.platformValue == this }

--- a/lib/src/test/java/com/squareup/recycler/SwipeUnderviewTests.kt
+++ b/lib/src/test/java/com/squareup/recycler/SwipeUnderviewTests.kt
@@ -1,0 +1,185 @@
+package com.squareup.recycler
+
+import android.view.View
+import com.google.common.truth.Truth.assertThat
+import com.nhaarman.mockitokotlin2.mock
+import com.nhaarman.mockitokotlin2.whenever
+import com.squareup.cycler.SwipeBindData
+import com.squareup.cycler.SwipeDirection
+import com.squareup.cycler.SwipeDirection.Companion.BOTH
+import com.squareup.cycler.SwipeDirection.Companion.BOTH_ABSOLUTE
+import com.squareup.cycler.SwipeDirection.END
+import com.squareup.cycler.SwipeDirection.LEFT
+import com.squareup.cycler.SwipeDirection.RIGHT
+import com.squareup.cycler.SwipeDirection.START
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.robolectric.RobolectricTestRunner
+import java.util.EnumSet
+
+/**
+ * Tests the basic algoritms that translate swipe movement into our API values.
+ */
+@RunWith(RobolectricTestRunner::class)
+class SwipeUnderviewTests {
+
+  private fun createSwipe(
+    width: Int,
+    dX: Float,
+    layoutDirection: Int,
+    allowedDirections: Set<SwipeDirection>
+  ): SwipeBindData<Int> {
+    val swipedView = mock<View>()
+    whenever(swipedView.layoutDirection).thenReturn(layoutDirection)
+    whenever(swipedView.width).thenReturn(width)
+    return SwipeBindData(
+        dataItem = 1,
+        swipedView = swipedView,
+        allowedDirections = allowedDirections
+    ).apply { bind(dX) }
+  }
+
+  @Test
+  fun both_and_right() {
+    val data = createSwipe(
+        width = 100,
+        dX = 10f,
+        layoutDirection = View.LAYOUT_DIRECTION_LTR,
+        allowedDirections = BOTH
+    )
+    assertThat(data.isValid).isTrue()
+    assertThat(data.direction).isEqualTo(SwipeDirection.END)
+    assertThat(data.percentage).isEqualTo(.1f)
+  }
+
+  @Test
+  fun both_and_right_rtl() {
+    val data = createSwipe(
+        width = 100,
+        dX = 10f,
+        layoutDirection = View.LAYOUT_DIRECTION_RTL,
+        allowedDirections = BOTH
+    )
+    assertThat(data.isValid).isTrue()
+    assertThat(data.direction).isEqualTo(SwipeDirection.START)
+    assertThat(data.percentage).isEqualTo(.1f)
+  }
+
+  @Test
+  fun start_and_ltr() {
+    val data = createSwipe(
+        width = 100,
+        dX = -5f,
+        layoutDirection = View.LAYOUT_DIRECTION_LTR,
+        allowedDirections = EnumSet.of(START)
+    )
+    assertThat(data.isValid).isTrue()
+    assertThat(data.direction).isEqualTo(START)
+    assertThat(data.percentage).isEqualTo(.05f)
+  }
+
+  @Test
+  fun left_and_rtl() {
+    val data = createSwipe(
+        width = 100,
+        dX = -5f,
+        layoutDirection = View.LAYOUT_DIRECTION_RTL,
+        allowedDirections = EnumSet.of(LEFT)
+    )
+    assertThat(data.isValid).isTrue()
+    assertThat(data.direction).isEqualTo(LEFT)
+    assertThat(data.percentage).isEqualTo(.05f)
+  }
+
+  @Test
+  fun both_absolute_and_trl() {
+    val data = createSwipe(
+        width = 100,
+        dX = 5f,
+        layoutDirection = View.LAYOUT_DIRECTION_RTL,
+        allowedDirections = BOTH_ABSOLUTE
+    )
+    assertThat(data.isValid).isTrue()
+    assertThat(data.direction).isEqualTo(RIGHT)
+    assertThat(data.percentage).isEqualTo(.05f)
+  }
+
+  @Test
+  fun zero_width() {
+    val data = createSwipe(
+        width = 0,
+        dX = -5f,
+        layoutDirection = View.LAYOUT_DIRECTION_LTR,
+        allowedDirections = BOTH
+    )
+    assertThat(data.isValid).isFalse()
+  }
+
+  @Test
+  fun invalid_width() {
+    val data = createSwipe(
+        width = -1,
+        dX = -5f,
+        layoutDirection = View.LAYOUT_DIRECTION_LTR,
+        allowedDirections = BOTH
+    )
+    assertThat(data.isValid).isFalse()
+  }
+
+  @Test
+  fun disallowed_direction() {
+    val data = createSwipe(
+        width = 100,
+        dX = 5f,
+        layoutDirection = View.LAYOUT_DIRECTION_LTR,
+        allowedDirections = EnumSet.of(LEFT)
+    )
+    assertThat(data.isValid).isFalse()
+  }
+
+  @Test
+  fun prefers_relative_direction() {
+    val data = createSwipe(
+        width = 100,
+        dX = -5f,
+        layoutDirection = View.LAYOUT_DIRECTION_LTR,
+        allowedDirections = EnumSet.of(LEFT, START)
+    )
+    assertThat(data.isValid).isTrue()
+    assertThat(data.direction).isEqualTo(START)
+    assertThat(data.percentage).isEqualTo(.05f)
+
+    val data2 = createSwipe(
+        width = 100,
+        dX = -5f,
+        layoutDirection = View.LAYOUT_DIRECTION_RTL,
+        allowedDirections = EnumSet.of(LEFT, END)
+    )
+    assertThat(data2.isValid).isTrue()
+    assertThat(data2.direction).isEqualTo(END)
+    assertThat(data2.percentage).isEqualTo(.05f)
+  }
+
+  @Test
+  fun percentage_caps_at_100() {
+    val data = createSwipe(
+        width = 100,
+        dX = -150f,
+        layoutDirection = View.LAYOUT_DIRECTION_LTR,
+        allowedDirections = BOTH
+    )
+    assertThat(data.isValid).isTrue()
+    assertThat(data.direction).isEqualTo(START)
+    assertThat(data.percentage).isEqualTo(1f)
+
+    val data2 = createSwipe(
+        width = 100,
+        dX = 150f,
+        layoutDirection = View.LAYOUT_DIRECTION_RTL,
+        allowedDirections = BOTH
+    )
+    assertThat(data.isValid).isTrue()
+    assertThat(data.direction).isEqualTo(START)
+    assertThat(data.percentage).isEqualTo(1f)
+  }
+}

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/MutationsPage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/MutationsPage.kt
@@ -41,7 +41,7 @@ class MutationsPage : Page {
           ).show()
         }
 
-        onSwipeToRemove {
+        onSwiped { it ->
           Toast.makeText(
               recyclerView.context,
               "Swiped ${it.name} away",


### PR DESCRIPTION
 Swipe rename:
    - new methods without the `ToRemove` are added.
    - the old ones are deprecated.
    - canSwipe now should return which directions are allowed.
    
    Swipe underview:
    - Allows for one or more definitions of "under views"
      (using the same mechanism as StandardRowSpec).
    - An underview is created on swipe-start and updated on
      each new movement.
    - Swipe underview binding passes a triplet:
      original view (to set alpha or other properties),
      swipe percentage,
      original data item.
    
    Swipe info:
    - Swipe now informs of what direction it was swiped.
