### PR TITLE
Sample app: add mutations page

### DIFF
--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/BaseItem.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/BaseItem.kt
@@ -1,0 +1,25 @@
+package com.squareup.cycler.sampleapp
+
+sealed class BaseItem {
+
+  abstract val amount: Float
+
+  data class Item(
+    val id: Int,
+    val name: String,
+    val price: Float,
+    val quantity: Int
+  ) : BaseItem() {
+    override val amount = price * quantity
+  }
+
+  data class Discount(
+    val id: Int,
+    override val amount: Float,
+    val isStarred: Boolean = false
+  ): BaseItem() {
+    init { require(amount < 0f) }
+  }
+}
+
+data class GrandTotal(val total: Float)

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/ItemView.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/ItemView.kt
@@ -2,20 +2,46 @@ package com.squareup.cycler.sampleapp
 
 import android.content.Context
 import android.graphics.Color
+import android.graphics.drawable.GradientDrawable
+import android.graphics.drawable.GradientDrawable.Orientation.TOP_BOTTOM
+import android.view.View
+import android.widget.ImageView
+import android.widget.ImageView.ScaleType.CENTER
 import android.widget.LinearLayout
+import android.widget.LinearLayout.LayoutParams.MATCH_PARENT
 import android.widget.LinearLayout.LayoutParams.WRAP_CONTENT
+import androidx.appcompat.widget.AppCompatImageView
 import androidx.appcompat.widget.AppCompatTextView
-import com.squareup.cycler.sampleapp.RecyclerActivity.BaseItem.Item
+import com.squareup.cycler.sampleapp.BaseItem.Item
 
+/**
+ * Custom view to instance programmatically from the configuration of pages.
+ */
 class ItemView(
-  context: Context
+  context: Context,
+  val showDragHandle: Boolean
 ) : LinearLayout(context, null, 0, R.style.LineContainer) {
+
+  lateinit var dragHandle: ImageView
   private val name = AppCompatTextView(context)
   private val amount = AppCompatTextView(context)
 
   init {
-    // TODO: Consider using a layout file https://github.com/square/cycler/issues/24
     name.setTextAppearance(R.style.TextAppearance_Bold)
+    if (showDragHandle) {
+      dragHandle = AppCompatImageView(context)
+      dragHandle.visibility = if (showDragHandle) View.VISIBLE else View.GONE
+      dragHandle.setImageResource(R.drawable.drag_handle)
+      dragHandle.scaleType = CENTER
+      addView(dragHandle, LayoutParams(WRAP_CONTENT, MATCH_PARENT).apply { marginEnd = 20 })
+      // Use a background that doesn't depend on position if we are moving items around.
+      background = GradientDrawable(
+          TOP_BOTTOM,
+          intArrayOf(Color.rgb(240, 250, 255),
+              Color.WHITE)
+      )
+    }
+    // TODO: Consider a layout.xml file https://github.com/square/cycler/issues/24
     addView(name, LayoutParams(0, WRAP_CONTENT, 1f))
     addView(amount, LayoutParams(WRAP_CONTENT, WRAP_CONTENT))
   }
@@ -23,9 +49,11 @@ class ItemView(
   fun show(item: Item, isEven: Boolean) {
     name.text = item.name
     amount.text = item.amount.format()
-    setBackgroundColor(
-        if (isEven) Color.WHITE else Color.rgb(230, 245, 255)
-    )
+    if (!showDragHandle) {
+      setBackgroundColor(
+          if (isEven) Color.WHITE else Color.rgb(230, 245, 255)
+      )
+    }
   }
 }
 

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/MutationsPage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/MutationsPage.kt
@@ -1,0 +1,63 @@
+package com.squareup.cycler.sampleapp
+
+import android.widget.Toast
+import androidx.recyclerview.widget.RecyclerView
+import com.squareup.cycler.Recycler
+import com.squareup.cycler.dragHandle
+import com.squareup.cycler.enableMutations
+import com.squareup.cycler.sampleapp.BaseItem.Item
+import com.squareup.cycler.toDataSource
+
+class MutationsPage : Page {
+
+  override fun toString() = "Drag & Swipe"
+
+  override val options: List<Pair<String, (Boolean) -> Unit>> = listOf()
+
+  lateinit var cycler: Recycler<Item>
+
+  override fun config(recyclerView: RecyclerView) {
+    // Use a slightly different view with a drag handle.
+    // Make swipeable discounts
+    cycler = Recycler.adopt(recyclerView) {
+      // Cart-Item definition.
+      row<Item, ItemView> {
+        create { context ->
+          view = ItemView(context, showDragHandle = true)
+          dragHandle(view.dragHandle)
+          bind { index, item ->
+            view.show(item, index % 2 == 0)
+          }
+        }
+      }
+      enableMutations {
+        dragAndDropEnabled = true
+        swipeToRemoveEnabled = true
+        onMove { from, to ->
+          Toast.makeText(
+              recyclerView.context,
+              "Moved index $from to index $to",
+              Toast.LENGTH_SHORT
+          ).show()
+        }
+
+        onSwipeToRemove {
+          Toast.makeText(
+              recyclerView.context,
+              "Swiped ${it.name} away",
+              Toast.LENGTH_SHORT
+          ).show()
+        }
+      }
+    }
+    update()
+  }
+
+  private fun update() {
+    cycler.data = sampleData().toDataSource()
+  }
+
+  fun sampleData() = (1..20).map {
+    Item(it, "Product #$it", (it * 13.73).rem(100).toFloat(), 1)
+  }.toList()
+}

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/Page.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/Page.kt
@@ -1,0 +1,8 @@
+package com.squareup.cycler.sampleapp
+
+import androidx.recyclerview.widget.RecyclerView
+
+interface Page {
+  val options: List<Pair<String, (Boolean) -> Unit>>
+  fun config(recyclerView: RecyclerView)
+}

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/RecyclerActivity.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/RecyclerActivity.kt
@@ -1,137 +1,57 @@
 package com.squareup.cycler.sampleapp
 
 import android.os.Bundle
+import android.view.View
+import android.widget.AdapterView
+import android.widget.AdapterView.OnItemSelectedListener
+import android.widget.ArrayAdapter
 import android.widget.CheckBox
-import android.widget.TextView
+import android.widget.LinearLayout
+import android.widget.Spinner
 import androidx.appcompat.app.AppCompatActivity
-import androidx.constraintlayout.widget.ConstraintLayout
 import androidx.recyclerview.widget.RecyclerView
-import com.squareup.cycler.Recycler
-import com.squareup.cycler.sampleapp.RecyclerActivity.BaseItem.Discount
-import com.squareup.cycler.sampleapp.RecyclerActivity.BaseItem.Item
-import com.squareup.cycler.toDataSource
 
-class RecyclerActivity : AppCompatActivity(R.layout.main_activity) {
+class RecyclerActivity: AppCompatActivity(R.layout.main_activity), OnItemSelectedListener {
 
-  private lateinit var cycler: Recycler<BaseItem>
-  private lateinit var data: List<BaseItem>
+  private val pages = arrayOf(SimplePage, MutationsPage())
 
-  private var showTotal = true
+  override fun onNothingSelected(parent: AdapterView<*>?) = Unit
+
+  override fun onItemSelected(
+    parent: AdapterView<*>?,
+    view: View?,
+    position: Int,
+    id: Long
+  ) {
+    optionsContainer.removeAllViews()
+    val page = pages[position]
+    page.options.forEach { (label, action) ->
+      CheckBox(this).apply {
+        text = label
+        setOnCheckedChangeListener { _, isChecked ->
+          action(isChecked)
+        }
+      }.also(optionsContainer::addView)
+    }
+    recyclerView.adapter = null
+    pages[position].config(recyclerView)
+  }
+
+  private lateinit var optionsContainer: LinearLayout
+  private lateinit var recyclerView: RecyclerView
 
   override fun onCreate(savedInstanceState: Bundle?) {
     super.onCreate(savedInstanceState)
 
-    data = sampleList()
-    findViewById<CheckBox>(R.id.show_total).apply {
-      isChecked = showTotal
-      setOnCheckedChangeListener { _, isChecked ->
-        showTotal = isChecked
-        update()
-      }
-    }
-    configureRecycler()
-    update()
-  }
+    optionsContainer = findViewById(R.id.options)
+    recyclerView = findViewById(R.id.recycler_view)
 
-  private fun sampleList() =
-    listOf(
-        Item(1, "Apples", 1.53f, 5),
-        Item(2, "Coffee", 3.59f, 2),
-        Discount(5, -2f),
-        Item(3, "Bread", 1.14f, 1),
-        Item(4, "Ice cream", 2.93f, 2),
-        Discount(5, -5f, isStarred = true)
-    )
-
-  /**
-   * This runs once and provides all the info needed to show the Recycler.
-   * It's what defines what types of rows (items) we will have in it, and how they will be
-   * 1) created and 2) data-bound.
-   */
-  private fun configureRecycler() {
-    val recyclerView = findViewById<RecyclerView>(R.id.recycler_view)
-    cycler = Recycler.adopt(recyclerView) {
-
-      // Cart-Item definition.
-      row<Item, ItemView> {
-        create { context ->
-          view = ItemView(context)
-          bind { index, item ->
-            view.show(item, index % 2 == 0)
-          }
-        }
-      }
-
-      // Discount definition.
-      row<Discount, ConstraintLayout> {
-        // We are only defining for those Discount that are starred.
-        forItemsWhere { it.isStarred }
-        create(R.layout.starred_discount) {
-          val amount = view.findViewById<TextView>(R.id.amount)
-          bind { discount -> amount.text = discount.amount.format() }
-        }
-      }
-
-      // Discount definition.
-      row<Discount, ConstraintLayout> {
-        // The Discount that are not starred will fall into this definition instead.
-        create(R.layout.discount) {
-          val amount = view.findViewById<TextView>(R.id.amount)
-          bind { discount -> amount.text = discount.amount.format() }
-        }
-      }
-
-      // We define by separate if we want a footer item (it doesn't need to extend BaseItem).
-      extraItem<GrandTotal, TextView> {
-        create { context ->
-          view = TextView(context)
-          view.setTextAppearance(R.style.TextAppearance_Bold)
-          bind { total ->
-            view.text = "Grand total: ${total.total.format()}"
-          }
-        }
-      }
+    findViewById<Spinner>(R.id.page_selection).apply {
+      adapter = ArrayAdapter(context, android.R.layout.simple_spinner_item, pages)
+      setSelection(0)
+      onItemSelectedListener = this@RecyclerActivity
     }
   }
-
-  /**
-   * Updates the data to the already configured recycler.
-   */
-  private fun update() {
-
-    val total = data.fold(0f) {
-      acc, item -> acc + item.amount
-    }.coerceAtLeast(0f)
-
-    cycler.update {
-      data = this@RecyclerActivity.data.toDataSource()
-      extraItem = if (showTotal) GrandTotal(total) else null
-    }
-  }
-
-  sealed class BaseItem {
-
-    abstract val amount: Float
-
-    data class Item(
-      val id: Int,
-      val name: String,
-      val price: Float,
-      val quantity: Int
-    ) : BaseItem() {
-      override val amount = price * quantity
-    }
-
-    data class Discount(
-      val id: Int,
-      override val amount: Float,
-      val isStarred: Boolean = false
-    ): BaseItem() {
-      init { require(amount < 0f) }
-    }
-  }
-
-  data class GrandTotal(val total: Float)
 }
 
 

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/SimplePage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/SimplePage.kt
@@ -1,0 +1,110 @@
+package com.squareup.cycler.sampleapp
+
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.recyclerview.widget.RecyclerView
+import com.squareup.cycler.Recycler
+import com.squareup.cycler.sampleapp.BaseItem.Discount
+import com.squareup.cycler.sampleapp.BaseItem.Item
+import com.squareup.cycler.toDataSource
+
+object SimplePage : Page {
+
+  override fun toString() = "Simple"
+
+  private lateinit var cycler: Recycler<BaseItem>
+  private var data: List<BaseItem> = sampleList()
+
+  private var showTotal = false
+
+  override val options: List<Pair<String, (Boolean) -> Unit>> = listOf(
+      "Show total" to { isChecked -> showTotal(isChecked) }
+  )
+
+  private fun showTotal(isChecked: Boolean) {
+    showTotal = isChecked
+    update()
+  }
+
+  private fun sampleList() =
+    listOf(
+        Item(1, "Apples", 1.53f, 5),
+        Item(2, "Coffee", 3.59f, 2),
+        Discount(5, -2f),
+        Item(3, "Bread", 1.14f, 1),
+        Item(4, "Ice cream", 2.93f, 2),
+        Discount(5, -5f, isStarred = true)
+    )
+
+  /**
+   * This runs once and provides all the info needed to show the Recycler.
+   * It's what defines what types of rows (items) we will have in it, and how they will be
+   * 1) created and 2) data-bound.
+   */
+  override fun config(recyclerView: RecyclerView) {
+    cycler = Recycler.adopt(recyclerView) {
+      // Cart-Item definition.
+      row<Item, ItemView> {
+        create { context ->
+          view = ItemView(context, showDragHandle = false)
+          bind { index, item ->
+            view.show(item, index % 2 == 0)
+          }
+        }
+      }
+
+      // Discount definition.
+      row<Discount, ConstraintLayout> {
+        // We are only defining for those Discount that are starred.
+        forItemsWhere { it.isStarred }
+        create(R.layout.starred_discount) {
+          val amount = view.findViewById<TextView>(R.id.amount)
+          bind { discount -> amount.text = discount.amount.format() }
+        }
+      }
+
+      // Discount definition.
+      row<Discount, ConstraintLayout> {
+        // The Discount that are not starred will fall into this definition instead.
+        create(R.layout.discount) {
+          val amount = view.findViewById<TextView>(R.id.amount)
+          bind { discount -> amount.text = discount.amount.format() }
+        }
+      }
+
+      // We define by separate if we want a footer item (it doesn't need to extend BaseItem).
+      extraItem<GrandTotal, TextView> {
+        create { context ->
+          view = TextView(context)
+          view.setTextAppearance(R.style.TextAppearance_Bold)
+          bind { total ->
+            view.text = "Grand total: ${total.total.format()}"
+          }
+        }
+      }
+    }
+    update()
+  }
+
+  /**
+   * Updates the data to the already configured recycler.
+   */
+  private fun update() {
+
+    val total = data
+        .sumByFloat { it.amount }
+        .coerceAtLeast(0f)
+
+    cycler.update {
+      data = this@SimplePage.data.toDataSource()
+      extraItem = if (showTotal) GrandTotal(total) else null
+    }
+  }
+}
+
+/**
+ * Kotlin only offers [Iterable.sumBy] (Int) and [Iterable.sumByDouble].
+ */
+private inline fun <T : Any> Iterable<T>.sumByFloat(block: (T) -> Float): Float {
+  return sumByDouble { block(it).toDouble() }.toFloat()
+}

--- a/sample-app/src/main/res/drawable/drag_handle.xml
+++ b/sample-app/src/main/res/drawable/drag_handle.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M2,6C2,5.4478 2.4478,5 3,5L21,5C21.5522,5 22,5.4478 22,6C22,6.5522 21.5522,7 21,7L3,7C2.4478,7 2,6.5522 2,6ZM2,12C2,11.4478 2.4478,11 3,11L21,11C21.5522,11 22,11.4478 22,12C22,12.5522 21.5522,13 21,13L3,13C2.4478,13 2,12.5522 2,12ZM3,17C2.4478,17 2,17.4478 2,18C2,18.5522 2.4478,19 3,19L21,19C21.5522,19 22,18.5522 22,18C22,17.4478 21.5522,17 21,17L3,17Z"
+      android:fillColor="#468"
+      android:fillType="evenOdd"/>
+</vector>

--- a/sample-app/src/main/res/layout/main_activity.xml
+++ b/sample-app/src/main/res/layout/main_activity.xml
@@ -6,14 +6,23 @@
     android:layout_height="match_parent"
     >
 
-  <CheckBox
-      android:id="@+id/show_total"
+  <Spinner
+      android:id="@+id/page_selection"
       android:layout_width="0dp"
       android:layout_height="wrap_content"
-      android:text="Show total"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
       app:layout_constraintTop_toTopOf="parent"
+      />
+
+  <LinearLayout
+      android:id="@+id/options"
+      android:layout_width="0dp"
+      android:layout_height="wrap_content"
+      android:orientation="vertical"
+      app:layout_constraintStart_toStartOf="parent"
+      app:layout_constraintEnd_toEndOf="parent"
+      app:layout_constraintTop_toBottomOf="@+id/page_selection"
       />
 
   <androidx.recyclerview.widget.RecyclerView
@@ -22,7 +31,7 @@
       android:layout_height="0dp"
       app:layout_constraintStart_toStartOf="parent"
       app:layout_constraintEnd_toEndOf="parent"
-      app:layout_constraintTop_toBottomOf="@+id/show_total"
+      app:layout_constraintTop_toBottomOf="@+id/options"
       app:layout_constraintBottom_toBottomOf="parent"
       app:layoutManager="androidx.recyclerview.widget.LinearLayoutManager"
       />


### PR DESCRIPTION
The mutation pages shows how to configure simple drag&drop and swipe features.
It will also be useful for instrumentation tests.

The pages now implement a common interface to facilitate the main activity configuring them. Each page configures the recycler from scratch and updates data as desired. 

This mutations page uses the same Item as the simple page, but it's open to use different types if we need to.

PS: there's a small fix in a notification from swipe (getting the item before it's removed) that I will send as a separate commit anyway.