### PR TITLE
Fix swipe notification callback

### DIFF
--- a/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
@@ -268,10 +268,11 @@ private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : E
       }
 
       val position = viewHolder.adapterPosition
+      val dataItem = data.data[position]
       data.remove(position)
       recycler.view.adapter!!.notifyItemRemoved(position)
       // Tell the callback.
-      spec.onSwipeToRemove?.invoke(data.data[position])
+      spec.onSwipeToRemove?.invoke(dataItem)
     }
   }
 }


### PR DESCRIPTION
- It needs to get the item #position before removing not after.
- Discovered (and tested) when creating the sample page for swipes (that PR https://github.com/square/cycler/pull/19 when landed will serve to add an instrumentation test).