### PR TITLE
Do not allow for dragging if there is only one item

### DIFF
--- a/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
@@ -149,7 +149,8 @@ private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : E
         // If the data has been frozen (undergoing update) we cannot swap / drag anymore!
         return makeMovementFlags(0, 0)
       }
-      val dragFlags = if (spec.dragAndDropEnabled) {
+      val moreThanOne = data.data.size > 1
+      val dragFlags = if (spec.dragAndDropEnabled && moreThanOne) {
         data.forPosition(
             viewHolder.adapterPosition,
             onDataItem = { ItemTouchHelper.UP or ItemTouchHelper.DOWN },


### PR DESCRIPTION
- There are some limitations in the ability to dynamically enable/disable the dragging of items.
- This at least avoids the need for extra work to check for the one-item-only case.