### PR TITLE
Recycler.adopt: accept an optional layout provider

### DIFF
--- a/lib/src/main/java/com/squareup/cycler/RecyclerViews.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerViews.kt
@@ -1,8 +1,10 @@
 package com.squareup.cycler
 
+import android.content.Context
 import android.view.View
 import androidx.annotation.IdRes
 import androidx.recyclerview.widget.RecyclerView
+import androidx.recyclerview.widget.RecyclerView.LayoutManager
 import com.squareup.cycler.Recycler.Companion.create
 import com.squareup.cycler.Recycler.Config
 
@@ -14,5 +16,6 @@ import com.squareup.cycler.Recycler.Config
  */
 inline fun <I : Any> View.adoptRecyclerById(
   @IdRes recyclerId: Int,
+  noinline layoutProvider: ((Context) -> LayoutManager)? = null,
   crossinline block: Config<I>.() -> Unit
-): Recycler<I> = Recycler.adopt(findViewById(recyclerId), block)
+): Recycler<I> = Recycler.adopt(findViewById(recyclerId), layoutProvider, block)


### PR DESCRIPTION
- create allows for a layoutProvider to create the needed LayoutManager.
- adopt so far needed the RecyclerView to have already a LayoutManager provided.

This change allows an optional layoutProvider for adopt, so it can be specified in the same way.
Not passing one keeps the existing behavior (assume the RecyclerView has one) which might be already used in existing code.