### PR TITLE
Fix optional layout manager parameter

### DIFF
--- a/.github/workflows/android.yml
+++ b/.github/workflows/android.yml
@@ -28,9 +28,9 @@ jobs:
       # Allow tests to continue on other devices if they fail on one device.
       fail-fast: false
       matrix:
+        # The sample-app is minSdk 24.
         api-level:
-          - 21
-          - 23
+          - 24
           - 26
           - 29
     steps:

--- a/build.gradle
+++ b/build.gradle
@@ -21,6 +21,7 @@ buildscript {
     recyclerview: 'androidx.recyclerview:recyclerview:1.1.0',
     robolectric: 'org.robolectric:robolectric:4.3',
     truth: 'com.google.truth:truth:1.0',
+    test_rules: "androidx.test:rules:1.1.0",
   ]
 
   dependencies {

--- a/lib/src/main/java/com/squareup/cycler/Recycler.kt
+++ b/lib/src/main/java/com/squareup/cycler/Recycler.kt
@@ -627,7 +627,7 @@ class Recycler<I : Any> internal constructor(
       crossinline block: Config<I>.() -> Unit
     ): Recycler<I> {
       layoutProvider?.invoke(view.context)
-          .let { view.layoutManager = it }
+          ?.let { view.layoutManager = it }
       requireNotNull(view.layoutManager) {
         "RecyclerView needs a layoutManager assigned. " +
             "Assign one to the view, or pass a layoutProvider argument."

--- a/sample-app/build.gradle
+++ b/sample-app/build.gradle
@@ -31,4 +31,5 @@ dependencies {
   implementation 'androidx.core:core-ktx:1.2.0'
   implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
   implementation project(':lib')
+  androidTestImplementation deps.test_rules
 }

--- a/sample-app/src/androidTest/AndroidManifest.xml
+++ b/sample-app/src/androidTest/AndroidManifest.xml
@@ -1,0 +1,7 @@
+<manifest
+    xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.squareup.cycler.sampleapp.test"
+    >
+
+</manifest>
+

--- a/sample-app/src/androidTest/java/com.squareup.cycler.sampleapp.test/SmokeTest.kt
+++ b/sample-app/src/androidTest/java/com.squareup.cycler.sampleapp.test/SmokeTest.kt
@@ -1,0 +1,20 @@
+package com.squareup.cycler.sampleapp.test
+
+import androidx.test.rule.ActivityTestRule
+import com.squareup.cycler.sampleapp.RecyclerActivity
+import org.junit.Test
+
+class SmokeTest {
+
+  val rule = ActivityTestRule(
+      RecyclerActivity::class.java,
+      /* initialTouchMode */ true,
+      /*launchActivity*/ false
+  )
+
+  @Test
+  fun startApp() {
+    val activity = rule.launchActivity(null)
+    activity.finish()
+  }
+}


### PR DESCRIPTION
- When no layout manager lambda was provided the layout manager was nulled.
- That prevented pre-configured recyclers to be adopted.
- Added a smoke instrumentation test that covers this case and now pass.