### PR TITLE
Deprecating DataSource in favor of List

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,25 +214,6 @@ represents your recycler view. It has three properties:
 - `data`: the list of items to show.
 - `extraItem`: the extra item to add to the end (or null).
 
-Notice that `data` is of type `DataSource<I>`.
-
-`DataSource` is a simplified `List` interface:
-
-```kotlin
-interface DataSource<out T> {
-  operator fun get(i: Int): T
-  val size: Int
-}
-```
-
-You can convert an `Array` or a `List` to a DataSource
-using the extension method `toDataSource()`:
-`arrayOf(1, 2, 3).toDataSource()`.
-
-The advantage over requiring a Kotlin `List` is that you
-can implement your arbitrary DataSource without having to
-implement the whole `List` interface, which is bigger.
-
 ## Extensions
 
 Extensions are a mechanism to add simple-to-configure features

--- a/lib/src/main/java/com/squareup/cycler/DataSource.kt
+++ b/lib/src/main/java/com/squareup/cycler/DataSource.kt
@@ -19,10 +19,10 @@ typealias DataSource<T> = List<T>
   message = "Converting to DataSource is no longer necessary.",
   replaceWith = ReplaceWith("this")
 )
-fun <T> List<T>.toDataSource(): DataSource<T> = this
+fun <T> List<T>.toDataSource(): List<T> = this
 
 @Deprecated(
   message = "Converting to DataSource is no longer necessary.",
   replaceWith = ReplaceWith("toList()")
 )
-fun <T> Array<T>.toDataSource(): DataSource<T> = toList()
+fun <T> Array<T>.toDataSource(): List<T> = toList()

--- a/lib/src/main/java/com/squareup/cycler/DataSource.kt
+++ b/lib/src/main/java/com/squareup/cycler/DataSource.kt
@@ -1,26 +1,28 @@
 package com.squareup.cycler
 
 /**
- * Very minimal interface for the item list.
- * You can use extensions [Array.toDataSource] and [List.toDataSource].
+ * If you happened to have a custom implementation of [DataSource] you can
+ * subclass [AbstractList] which has the same abstract API surface.
+ *
+ * Ex:
+ * fun <T> Array<T>.toDataSource(): DataSource<T> {
+ *   return object : AbstractList<T>() {
+ *     override fun get(i: Int): T = this@toDataSource[i]
+ *     override val size get() = this@toDataSource.size
+ *   }
+ * }
  */
-interface DataSource<out T> {
-  operator fun get(i: Int): T
-  val size: Int
-  val isEmpty: Boolean
-    get() = size == 0
-}
+@Deprecated(message = "DataSource is now just an alias for List and will be removed in the future.")
+typealias DataSource<T> = List<T>
 
-fun <T> List<T>.toDataSource(): DataSource<T> {
-  return object : DataSource<T> {
-    override fun get(i: Int): T = this@toDataSource[i]
-    override val size get() = this@toDataSource.size
-  }
-}
+@Deprecated(
+  message = "Converting to DataSource is no longer necessary.",
+  replaceWith = ReplaceWith("this")
+)
+fun <T> List<T>.toDataSource(): DataSource<T> = this
 
-fun <T> Array<T>.toDataSource(): DataSource<T> {
-  return object : DataSource<T> {
-    override fun get(i: Int): T = this@toDataSource[i]
-    override val size get() = this@toDataSource.size
-  }
-}
+@Deprecated(
+  message = "Converting to DataSource is no longer necessary.",
+  replaceWith = ReplaceWith("toList()")
+)
+fun <T> Array<T>.toDataSource(): DataSource<T> = toList()

--- a/lib/src/main/java/com/squareup/cycler/DataSource.kt
+++ b/lib/src/main/java/com/squareup/cycler/DataSource.kt
@@ -23,6 +23,6 @@ fun <T> List<T>.toDataSource(): List<T> = this
 
 @Deprecated(
   message = "Converting to DataSource is no longer necessary.",
-  replaceWith = ReplaceWith("toList()")
+  replaceWith = ReplaceWith("asList()")
 )
-fun <T> Array<T>.toDataSource(): List<T> = toList()
+fun <T> Array<T>.toDataSource(): List<T> = asList()

--- a/lib/src/main/java/com/squareup/cycler/MutableDataSource.kt
+++ b/lib/src/main/java/com/squareup/cycler/MutableDataSource.kt
@@ -6,7 +6,7 @@ package com.squareup.cycler
  * be used externally.
  */
 internal class MutableDataSource<T>(
-  private val originalDataSource: DataSource<T>
+  private val originalDataSource: List<T>
 ) : AbstractList<T>() {
   private val mutationMap = MutationMap(originalDataSource.size)
   override fun get(index: Int) = originalDataSource[mutationMap[index]]

--- a/lib/src/main/java/com/squareup/cycler/MutableDataSource.kt
+++ b/lib/src/main/java/com/squareup/cycler/MutableDataSource.kt
@@ -7,10 +7,9 @@ package com.squareup.cycler
  */
 internal class MutableDataSource<T>(
   private val originalDataSource: DataSource<T>
-) : DataSource<T> {
-  private val mutationMap =
-    MutationMap(originalDataSource.size)
-  override fun get(i: Int) = originalDataSource[mutationMap[i]]
+) : AbstractList<T>() {
+  private val mutationMap = MutationMap(originalDataSource.size)
+  override fun get(index: Int) = originalDataSource[mutationMap[index]]
   override val size get() = mutationMap.size
   fun move(from: Int, to: Int) = mutationMap.move(from, to)
   fun remove(index: Int) = mutationMap.remove(index)

--- a/lib/src/main/java/com/squareup/cycler/Recycler.kt
+++ b/lib/src/main/java/com/squareup/cycler/Recycler.kt
@@ -131,7 +131,7 @@ class Recycler<I : Any> internal constructor(
   }
 
   fun clear() = update {
-    data = listOf<I>().toDataSource()
+    data = listOf()
     extraItem = null
   }
 
@@ -139,7 +139,7 @@ class Recycler<I : Any> internal constructor(
    * Property to assign the concrete data for the recycler.
    * @deprecated Use [update].
    */
-  var data: DataSource<I>
+  var data: List<I>
     get() = adapter.currentRecyclerData.data
     set(value) {
       update { data = value }

--- a/lib/src/main/java/com/squareup/cycler/RecyclerData.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerData.kt
@@ -8,7 +8,7 @@ import com.squareup.cycler.Recycler.Config
  */
 class RecyclerData<I : Any>(
   @PublishedApi internal val config: Config<I>,
-  originalData: DataSource<I>,
+  originalData: List<I>,
   val extraItem: Any?
 ) {
   /**
@@ -45,7 +45,7 @@ class RecyclerData<I : Any>(
   fun copyMutationMap() = mutableData.copyMutationMap()
 
   private val mutableData = MutableDataSource(originalData)
-  val data: DataSource<I> get() = mutableData
+  val data: List<I> get() = mutableData
   val hasExtraItem get() = extraItem != null
   val extraItemIndex get() = data.size
   val totalCount get() = data.size + if (hasExtraItem) 1 else 0
@@ -77,6 +77,6 @@ class RecyclerData<I : Any>(
   companion object {
     @Suppress("EXPERIMENTAL_API_USAGE")
     fun <T : Any> empty(): RecyclerData<T> =
-      RecyclerData(Config(), emptyList<T>().toDataSource(), null)
+      RecyclerData(Config(), emptyList(), null)
   }
 }

--- a/lib/src/main/java/com/squareup/cycler/RecyclerDiff.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerDiff.kt
@@ -5,8 +5,8 @@ import androidx.recyclerview.widget.DiffUtil
 /** Implements Android's DiffUtil.Callback (change comparison) based on an [ItemComparator]. */
 class DataSourceDiff<T>(
   private val helper: ItemComparator<T>,
-  private val oldList: DataSource<T>,
-  private val newList: DataSource<T>
+  private val oldList: List<T>,
+  private val newList: List<T>
 ) : DiffUtil.Callback() {
 
   override fun getOldListSize(): Int = oldList.size

--- a/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
@@ -176,21 +176,24 @@ class MutationExtensionSpec<T : Any> : ExtensionSpec<T> {
 
 /**
  * Define the extension method to get the current position-changes from a [Recycler].
- * It returns the mutation-map respect to the originally set [DataSource].
+ *
+ * @return The [MutationMap] originally set on [MutableDataSource] or
+ *         a new one if we don't have one to copy.
  */
 fun <I : Any> Recycler<I>.getCurrentMutations(): MutationMap {
   return extension<MutationExtension<I>>()?.data?.copyMutationMap() ?: MutationMap()
 }
 
 /**
- * Define the extension method to get the [DataSource] including all the changes from a [Recycler].
- * It returns a copy of the DataSource so it's immutable (and developer can't change the internal one).
+ * Define the extension method to get the data [List] including all the changes from a [Recycler].
+ *
+ * @return A copy of the data so it's immutable (and developer can't change the internal one).
  */
-fun <I : Any> Recycler<I>.getMutatedData(): DataSource<I> {
+fun <I : Any> Recycler<I>.getMutatedData(): List<I> {
   return data.let { source ->
     mutableListOf<I>().apply {
-      addAll((0 until source.size).asSequence().map(source::get))
-    }.toDataSource()
+      addAll((source.indices).asSequence().map(source::get))
+    }
   }
 }
 

--- a/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
@@ -175,7 +175,7 @@ class MutationExtensionSpec<T : Any> : ExtensionSpec<T> {
 }
 
 /**
- * Define the extension method to get the current position-changes from a [Recycler].
+ * Extension method to get the current position-changes from a [Recycler].
  *
  * @return The [MutationMap] originally set on [MutableDataSource] or
  *         a new one if we don't have one to copy.
@@ -185,7 +185,7 @@ fun <I : Any> Recycler<I>.getCurrentMutations(): MutationMap {
 }
 
 /**
- * Define the extension method to get the data [List] including all the changes from a [Recycler].
+ * Extension method to get the data [List] including all the changes from a [Recycler].
  *
  * @return A copy of the data so it's immutable (and developer can't change the internal one).
  */

--- a/lib/src/main/java/com/squareup/cycler/Update.kt
+++ b/lib/src/main/java/com/squareup/cycler/Update.kt
@@ -35,9 +35,7 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
   }
 
   // New values, initialized to the old ones.
-  var data by Delegates.observable<DataSource<I>>(
-      oldRecyclerData.data
-  ) { _, _, _ -> addedChunks.clear() }
+  var data by Delegates.observable(oldRecyclerData.data) { _, _, _ -> addedChunks.clear() }
   var extraItem: Any? = oldRecyclerData.extraItem
 
   /**
@@ -116,8 +114,8 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
           notifications += { adapter ->
             val positionAt = oldRecyclerData.data.size
             val count = addedChunks.asSequence()
-                .map(List<I>::size)
-                .sum()
+              .map(List<I>::size)
+              .sum()
             adapter.notifyItemRangeInserted(positionAt, count)
           }
         }
@@ -171,7 +169,7 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
    * As mutationMap just changes items in the already existing range.
    */
   private fun concatenateAddedChunks() = mutableListOf<I>().apply {
-    addAll((0 until data.size).asSequence().map(data::get))
+    addAll((data.indices).asSequence().map(data::get))
     addAll(addedChunks.asSequence().flatten())
-  }.toDataSource()
+  }
 }

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/MutationsPage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/MutationsPage.kt
@@ -6,7 +6,6 @@ import com.squareup.cycler.Recycler
 import com.squareup.cycler.dragHandle
 import com.squareup.cycler.enableMutations
 import com.squareup.cycler.sampleapp.BaseItem.Item
-import com.squareup.cycler.toDataSource
 
 class MutationsPage : Page {
 
@@ -54,10 +53,10 @@ class MutationsPage : Page {
   }
 
   private fun update() {
-    cycler.data = sampleData().toDataSource()
+    cycler.data = sampleData()
   }
 
-  fun sampleData() = (1..20).map {
+  private fun sampleData() = (1..20).map {
     Item(it, "Product #$it", (it * 13.73).rem(100).toFloat(), 1)
-  }.toList()
+  }
 }

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/SimplePage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/SimplePage.kt
@@ -6,7 +6,6 @@ import androidx.recyclerview.widget.RecyclerView
 import com.squareup.cycler.Recycler
 import com.squareup.cycler.sampleapp.BaseItem.Discount
 import com.squareup.cycler.sampleapp.BaseItem.Item
-import com.squareup.cycler.toDataSource
 
 object SimplePage : Page {
 
@@ -96,7 +95,7 @@ object SimplePage : Page {
         .coerceAtLeast(0f)
 
     cycler.update {
-      data = this@SimplePage.data.toDataSource()
+      data = this@SimplePage.data
       extraItem = if (showTotal) GrandTotal(total) else null
     }
   }


### PR DESCRIPTION
## Context

@helios175  and I are working on various improvements to Cycler this week as a part of hack week.

## Overview

Datasource was introduced to make it easy to implement a list without forcing users to implement the full `List` interface. However:
* `DataSource` and `AbstractList` have the exact same abstract methods
* Having a `DataSource` wrapper has some implications in our code.  It forces users to unnecessarily create a new wrapper on every invocation of `toDataSource()` (even when the passed in list is the same). 
* This is anecdotal, but any time I've used cycler I was always working with a `List` (or some data structure that could easily be converted to `List` via std lib extensions). Removing `DataSource` eliminates an extra step when trying to update Cycler's data.
