### PR TITLE
Enable drag and drop in grid layout

### DIFF
--- a/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
@@ -73,6 +73,12 @@ class MutationExtensionSpec<T : Any> : ExtensionSpec<T> {
   var dragAndDropEnabled = false
 
   /**
+   * Determine whether items can be dragged left and right in the recycler view or not.
+   * If [dragAndDropEnabled] == false, this flag is ignored.
+   */
+  var leftRightDragAndDropEnabled = false
+
+  /**
    * Determine whether a drag can be started by long pressing an item.
    */
   var longPressDragEnabled = false
@@ -340,7 +346,7 @@ private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : E
       val dragFlags = if (spec.dragAndDropEnabled && moreThanOne) {
         data.forPosition(
             viewHolder.adapterPosition,
-            onDataItem = { ItemTouchHelper.UP or ItemTouchHelper.DOWN },
+            onDataItem = dataItemDragFlags(),
             onExtraItem = { 0 },
             orElse = { 0 }
         )
@@ -443,6 +449,14 @@ private class MutationExtension<T : Any>(val spec: MutationExtensionSpec<T>) : E
         }
       }
       lastActionState = actionState
+    }
+
+    private fun dataItemDragFlags(): (T) -> Int {
+      return if (spec.leftRightDragAndDropEnabled) {
+        { ItemTouchHelper.UP or ItemTouchHelper.DOWN or ItemTouchHelper.RIGHT or ItemTouchHelper.LEFT }
+      } else {
+        { ItemTouchHelper.UP or ItemTouchHelper.DOWN }
+      }
     }
 
     private fun removeSwipeState() {

--- a/sample-app/TODO.md
+++ b/sample-app/TODO.md
@@ -1,1 +1,0 @@
-# This directory will contain a sample Android app using the Square Cycle lib.

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/Constants.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/Constants.kt
@@ -1,0 +1,3 @@
+package com.squareup.cycler.sampleapp
+
+const val GRID_SPAN_COUNT = 4

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/GridData.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/GridData.kt
@@ -1,0 +1,7 @@
+package com.squareup.cycler.sampleapp
+
+import com.squareup.cycler.sampleapp.BaseItem.Item
+
+fun gridSampleData() = (1..20).map {
+  Item(it, "Product #$it", (it * 13.73).rem(100).toFloat(), 1)
+}

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/GridMutationsPage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/GridMutationsPage.kt
@@ -1,0 +1,62 @@
+package com.squareup.cycler.sampleapp
+
+import android.widget.Toast
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.squareup.cycler.Recycler
+import com.squareup.cycler.enableMutations
+import com.squareup.cycler.sampleapp.BaseItem.Item
+
+/**
+ * What makes this page different from [MutationsPage] is that
+ * 1. we set a [GridLayoutManager] on the [RecyclerView],
+ * 2. enable [com.squareup.cycler.MutationExtensionSpec.dragAndDropEnabled]
+ * 3. enable [com.squareup.cycler.MutationExtensionSpec.longPressDragEnabled]
+ * 4. enable [com.squareup.cycler.MutationExtensionSpec.leftRightDragAndDropEnabled]
+ * 5. disable [com.squareup.cycler.MutationExtensionSpec.swipeToRemoveEnabled]
+ */
+class GridMutationsPage : Page {
+
+  override fun toString() = "Grid Drag and Drop"
+
+  override val options: List<Pair<String, (Boolean) -> Unit>> = listOf()
+
+  lateinit var cycler: Recycler<Item>
+
+  override fun config(recyclerView: RecyclerView) {
+    recyclerView.layoutManager = GridLayoutManager(recyclerView.context, GRID_SPAN_COUNT)
+
+    cycler = Recycler.adopt(recyclerView) {
+      row<Item, ItemView> {
+        create { context ->
+          view = ItemView(context, showDragHandle = false)
+          bind { index, item ->
+            view.show(item, index % 2 == 0)
+          }
+        }
+      }
+      enableMutations {
+        dragAndDropEnabled = true
+        longPressDragEnabled = true
+        leftRightDragAndDropEnabled = true
+        onMove { from, to ->
+          // we receive an onMove call on every position change, as user drags *before* finger lift.
+          // Can be very spammy to log here.
+        }
+
+        onDragDrop { from, to ->
+          Toast.makeText(
+            recyclerView.context,
+            "DragDrop from index $from to index $to",
+            Toast.LENGTH_SHORT
+          ).show()
+        }
+      }
+    }
+    update()
+  }
+
+  private fun update() {
+    cycler.data = gridSampleData()
+  }
+}

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/GridPage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/GridPage.kt
@@ -1,0 +1,105 @@
+package com.squareup.cycler.sampleapp
+
+import android.widget.TextView
+import androidx.constraintlayout.widget.ConstraintLayout
+import androidx.recyclerview.widget.GridLayoutManager
+import androidx.recyclerview.widget.RecyclerView
+import com.squareup.cycler.Recycler
+import com.squareup.cycler.sampleapp.BaseItem.Discount
+import com.squareup.cycler.sampleapp.BaseItem.Item
+
+/**
+ * What makes this page different from [SimplePage] is that we set a [GridLayoutManager] on
+ * the [RecyclerView].
+ */
+object GridPage : Page {
+
+  override fun toString() = "Grid"
+
+  private lateinit var cycler: Recycler<BaseItem>
+  private var data: List<BaseItem> = gridSampleData()
+
+  private var showTotal = false
+
+  override val options: List<Pair<String, (Boolean) -> Unit>> = listOf(
+    "Show total" to { isChecked -> showTotal(isChecked) }
+  )
+
+  private fun showTotal(isChecked: Boolean) {
+    showTotal = isChecked
+    update()
+  }
+
+  /**
+   * This runs once and provides all the info needed to show the Recycler.
+   * It's what defines what types of rows (items) we will have in it, and how they will be
+   * 1) created and 2) data-bound.
+   */
+  override fun config(recyclerView: RecyclerView) {
+    recyclerView.layoutManager = GridLayoutManager(recyclerView.context, GRID_SPAN_COUNT)
+    cycler = Recycler.adopt(recyclerView) {
+      // Cart-Item definition.
+      row<Item, ItemView> {
+        create { context ->
+          view = ItemView(context, showDragHandle = false)
+          bind { index, item ->
+            view.show(item, index % 2 == 0)
+          }
+        }
+      }
+
+      // Discount definition.
+      row<Discount, ConstraintLayout> {
+        // We are only defining for those Discount that are starred.
+        forItemsWhere { it.isStarred }
+        create(R.layout.starred_discount) {
+          val amount = view.findViewById<TextView>(R.id.amount)
+          bind { discount -> amount.text = discount.amount.format() }
+        }
+      }
+
+      // Discount definition.
+      row<Discount, ConstraintLayout> {
+        // The Discount that are not starred will fall into this definition instead.
+        create(R.layout.discount) {
+          val amount = view.findViewById<TextView>(R.id.amount)
+          bind { discount -> amount.text = discount.amount.format() }
+        }
+      }
+
+      // We define by separate if we want a footer item (it doesn't need to extend BaseItem).
+      extraItem<GrandTotal, TextView> {
+        create { context ->
+          view = TextView(context)
+          view.setTextAppearance(R.style.TextAppearance_Bold)
+          bind { total ->
+            view.text = "Grand total: ${total.total.format()}"
+          }
+        }
+      }
+    }
+    update()
+  }
+
+  /**
+   * Updates the data to the already configured recycler.
+   */
+  private fun update() {
+
+    val total = data
+      .sumByFloat { it.amount }
+      .coerceAtLeast(0f)
+
+    cycler.update {
+      data = this@GridPage.data
+      extraItem = if (showTotal) GrandTotal(total) else null
+    }
+  }
+}
+
+/**
+ * Kotlin only offers [Iterable.sumBy] (Int) and [Iterable.sumByDouble].
+ */
+private inline fun <T : Any> Iterable<T>.sumByFloat(block: (T) -> Float): Float {
+  return sumByDouble { block(it).toDouble() }.toFloat()
+}

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/RecyclerActivity.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/RecyclerActivity.kt
@@ -13,7 +13,7 @@ import androidx.recyclerview.widget.RecyclerView
 
 class RecyclerActivity : AppCompatActivity(R.layout.main_activity), OnItemSelectedListener {
 
-  private val pages = arrayOf(SimplePage, MutationsPage())
+  private val pages = arrayOf(SimplePage, MutationsPage(), GridPage, GridMutationsPage())
 
   override fun onNothingSelected(parent: AdapterView<*>?) = Unit
 


### PR DESCRIPTION
Cycler doesn't fully support drag and drop in grid mode (i.e. using GridLayoutManager). Dragging is limited to up/down, not left right. This should fix that.

Most of this PR is about adding to the sample app to both show how to use Grid layout and test left/right/up/down drag and drop in grid mode.

![2021-12-03 17 39 19](https://user-images.githubusercontent.com/1980553/144891156-9f46f5a6-3b71-4b71-a242-be1553bf6200.gif)
