### PR TITLE
Re-introduce DataSource

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,24 @@ represents your recycler view. It has three properties:
 - `data`: the list of items to show.
 - `extraItem`: the extra item to add to the end (or null).
 
+Notice that `data` is of type `DataSource<I>`.
+
+`DataSource` is a simplified `List` interface:
+
+```kotlin
+interface DataSource<out T> {
+  operator fun get(i: Int): T
+  val size: Int
+}
+```
+
+You can convert an `Array` or a `List` to a DataSource
+using the extension method `toDataSource()`:
+`arrayOf(1, 2, 3).toDataSource()`.
+
+The advantage over requiring a Kotlin `List` is that you
+can implement your arbitrary DataSource without having to
+implement the whole `List` interface, which is bigger.
 ## Extensions
 
 Extensions are a mechanism to add simple-to-configure features

--- a/lib/src/main/java/com/squareup/cycler/MutableDataSource.kt
+++ b/lib/src/main/java/com/squareup/cycler/MutableDataSource.kt
@@ -6,8 +6,8 @@ package com.squareup.cycler
  * be used externally.
  */
 internal class MutableDataSource<T>(
-  private val originalDataSource: List<T>
-) : AbstractList<T>() {
+  private val originalDataSource: DataSource<T>
+) : DataSource<T> {
   private val mutationMap = MutationMap(originalDataSource.size)
   override fun get(index: Int) = originalDataSource[mutationMap[index]]
   override val size get() = mutationMap.size

--- a/lib/src/main/java/com/squareup/cycler/Recycler.kt
+++ b/lib/src/main/java/com/squareup/cycler/Recycler.kt
@@ -131,7 +131,7 @@ class Recycler<I : Any> internal constructor(
   }
 
   fun clear() = update {
-    data = listOf()
+    data = listOf<I>().toDataSource()
     extraItem = null
   }
 
@@ -139,7 +139,7 @@ class Recycler<I : Any> internal constructor(
    * Property to assign the concrete data for the recycler.
    * @deprecated Use [update].
    */
-  var data: List<I>
+  var data: DataSource<I>
     get() = adapter.currentRecyclerData.data
     set(value) {
       update { data = value }

--- a/lib/src/main/java/com/squareup/cycler/RecyclerData.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerData.kt
@@ -8,7 +8,7 @@ import com.squareup.cycler.Recycler.Config
  */
 class RecyclerData<I : Any>(
   @PublishedApi internal val config: Config<I>,
-  originalData: List<I>,
+  originalData: DataSource<I>,
   val extraItem: Any?
 ) {
   /**
@@ -45,7 +45,7 @@ class RecyclerData<I : Any>(
   fun copyMutationMap() = mutableData.copyMutationMap()
 
   private val mutableData = MutableDataSource(originalData)
-  val data: List<I> get() = mutableData
+  val data: DataSource<I> get() = mutableData
   val hasExtraItem get() = extraItem != null
   val extraItemIndex get() = data.size
   val totalCount get() = data.size + if (hasExtraItem) 1 else 0
@@ -77,6 +77,6 @@ class RecyclerData<I : Any>(
   companion object {
     @Suppress("EXPERIMENTAL_API_USAGE")
     fun <T : Any> empty(): RecyclerData<T> =
-      RecyclerData(Config(), emptyList(), null)
+      RecyclerData(Config(), emptyList<T>().toDataSource(), null)
   }
 }

--- a/lib/src/main/java/com/squareup/cycler/RecyclerDiff.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerDiff.kt
@@ -5,8 +5,8 @@ import androidx.recyclerview.widget.DiffUtil
 /** Implements Android's DiffUtil.Callback (change comparison) based on an [ItemComparator]. */
 class DataSourceDiff<T>(
   private val helper: ItemComparator<T>,
-  private val oldList: List<T>,
-  private val newList: List<T>
+  private val oldList: DataSource<T>,
+  private val newList: DataSource<T>
 ) : DiffUtil.Callback() {
 
   override fun getOldListSize(): Int = oldList.size

--- a/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
+++ b/lib/src/main/java/com/squareup/cycler/RecyclerMutations.kt
@@ -189,11 +189,11 @@ fun <I : Any> Recycler<I>.getCurrentMutations(): MutationMap {
  *
  * @return A copy of the data so it's immutable (and developer can't change the internal one).
  */
-fun <I : Any> Recycler<I>.getMutatedData(): List<I> {
+fun <I : Any> Recycler<I>.getMutatedData(): DataSource<I> {
   return data.let { source ->
     mutableListOf<I>().apply {
-      addAll((source.indices).asSequence().map(source::get))
-    }
+      addAll((0 until source.size).asSequence().map(source::get))
+    }.toDataSource()
   }
 }
 

--- a/lib/src/main/java/com/squareup/cycler/Update.kt
+++ b/lib/src/main/java/com/squareup/cycler/Update.kt
@@ -35,7 +35,9 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
   }
 
   // New values, initialized to the old ones.
-  var data by Delegates.observable(oldRecyclerData.data) { _, _, _ -> addedChunks.clear() }
+  var data by Delegates.observable<DataSource<I>>(
+    oldRecyclerData.data
+  ) { _, _, _ -> addedChunks.clear() }
   var extraItem: Any? = oldRecyclerData.extraItem
 
   /**
@@ -53,7 +55,7 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
   var detectMoves: Boolean = true
 
   private val addedChunks = mutableListOf<List<I>>()
-  private val dataReplaced get() = oldRecyclerData.data !== data
+  private val dataReplaced get() = oldRecyclerData.data != data
   private val dataAdded get() = !dataReplaced && addedChunks.isNotEmpty()
   private val newData get() = data
 
@@ -169,7 +171,7 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
    * As mutationMap just changes items in the already existing range.
    */
   private fun concatenateAddedChunks() = mutableListOf<I>().apply {
-    addAll((data.indices).asSequence().map(data::get))
+    addAll((0 until data.size).asSequence().map(data::get))
     addAll(addedChunks.asSequence().flatten())
-  }
+  }.toDataSource()
 }

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/MutationsPage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/MutationsPage.kt
@@ -6,6 +6,7 @@ import com.squareup.cycler.Recycler
 import com.squareup.cycler.dragHandle
 import com.squareup.cycler.enableMutations
 import com.squareup.cycler.sampleapp.BaseItem.Item
+import com.squareup.cycler.toDataSource
 
 class MutationsPage : Page {
 
@@ -53,10 +54,10 @@ class MutationsPage : Page {
   }
 
   private fun update() {
-    cycler.data = sampleData()
+    cycler.data = sampleData().toDataSource()
   }
 
   private fun sampleData() = (1..20).map {
     Item(it, "Product #$it", (it * 13.73).rem(100).toFloat(), 1)
-  }
+  }.toList()
 }

--- a/sample-app/src/main/java/com/squareup/cycler/sampleapp/SimplePage.kt
+++ b/sample-app/src/main/java/com/squareup/cycler/sampleapp/SimplePage.kt
@@ -6,6 +6,7 @@ import androidx.recyclerview.widget.RecyclerView
 import com.squareup.cycler.Recycler
 import com.squareup.cycler.sampleapp.BaseItem.Discount
 import com.squareup.cycler.sampleapp.BaseItem.Item
+import com.squareup.cycler.toDataSource
 
 object SimplePage : Page {
 
@@ -95,7 +96,7 @@ object SimplePage : Page {
         .coerceAtLeast(0f)
 
     cycler.update {
-      data = this@SimplePage.data
+      data = this@SimplePage.data.toDataSource()
       extraItem = if (showTotal) GrandTotal(total) else null
     }
   }


### PR DESCRIPTION
- `DataSource` has a smaller API surface than `List/AbstractList`.
- It doesn't come with comparison-by-value (deep equals).
- It prevents users that handle these `DataSource`s to force a comparison-by-value when comparing their structures.

This is mostly a revert of:
- https://github.com/square/cycler/commit/72c834ef302d0df2c263297bfb1ee6d5a1ce59e6
- https://github.com/square/cycler/commit/3206a2866cfd618d7d2d3a7acdddeddd13e86126

- [ ] Test with a T2 and the 25k items account.