### PR TITLE
Recycler.Update.allowSynchronousUpdate

### DIFF
--- a/lib/src/main/java/com/squareup/cycler/Recycler.kt
+++ b/lib/src/main/java/com/squareup/cycler/Recycler.kt
@@ -175,7 +175,7 @@ class Recycler<I : Any> internal constructor(
     // This tells which update is the last one, the one that will be applied in case of race.
     currentUpdate = newUpdate
     val updateWork = newUpdate.generateUpdateWork(adapter.itemComparator)
-    if (updateWork.asyncWork.isEmpty()) {
+    if (updateWork.isSynchronous()) {
       // If there's no async work we don't need to run on the UI thread and lose UI frames.
       applyNotifications(updateWork.notifications, newUpdate)
     } else {


### PR DESCRIPTION
This flag tells if an update *can* be done synchronously, by sending notifications to the adapter directly inside the update call. Defaults to false.

This way a user can opt-in into this behavior which, in certain usages, might cause issues (Recycler does not like notifications when there's a pending relayout, or the recycler is scrolling).