### PR TITLE
Add UpdateMode for specifying synchronous or asynchronous behavior when populating and updating lists

### DIFF
--- a/lib/src/main/java/com/squareup/cycler/Update.kt
+++ b/lib/src/main/java/com/squareup/cycler/Update.kt
@@ -5,6 +5,12 @@ import androidx.recyclerview.widget.DiffUtil
 import androidx.recyclerview.widget.DiffUtil.DiffResult
 import androidx.recyclerview.widget.RecyclerView.Adapter
 import com.squareup.cycler.Recycler.Config
+import com.squareup.cycler.Update.UpdateMode.Async
+import com.squareup.cycler.Update.UpdateMode.Sync
+import com.squareup.cycler.Update.UpdateType.Adding
+import com.squareup.cycler.Update.UpdateType.NoOp
+import com.squareup.cycler.Update.UpdateType.Populating
+import com.squareup.cycler.Update.UpdateType.Replacing
 import kotlin.properties.Delegates
 
 /**
@@ -35,16 +41,51 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
   }
 
   /**
-   * If true a call to [Recycler.update] might update the recycler view (send adapter notifications)
-   * in the same call without posting / using coroutines. This happens if the update is trivial
-   * (no list diffing necessary).
+   * Controls the update behavior when populating a list (i.e. going from an empty dataset to a non-
+   * empty dataset) for the first time.
    *
-   * Disabled by default as, depending on the usage, calls to update might happen when the recycler
-   * view is scrolling or laying out and recycler view throws an exception (and this library cannot
-   * find out). Its use however is encouraged provided no calls to update are triggered inside
-   * an onScrollChanged or a relayout pending (when showing/hiding a keyboard for instance).
+   * If set to [Sync], a call to [Recycler.update] will update the recycler view (send adapter
+   * notifications) in the same call without posting / using coroutines.
+   *
+   * If set to [Async], a call to [Recycler.update] will update the recycler view by posting / using
+   * coroutines. This isn't actually necessary when populating the list for the first time but it
+   * mimics the previous behavior of this library.
+   *
+   * If no [itemComparator] is provided in your [Recycler.Config], initial dataset updates will
+   * always be processed synchronously.
+   *
+   * Set to [Async] by default as, depending on the usage, calls to update might happen when the
+   * recycler view is scrolling or laying out and recycler view throws an exception (and this
+   * library cannot find out). Its use however is encouraged provided no calls to update are
+   * triggered inside an onScrollChanged or a relayout pending (when showing/hiding a keyboard for
+   * instance).
    */
-  var allowSynchronousUpdate: Boolean = false
+  var populateMode: UpdateMode = Async
+
+  /**
+   * Controls the update behavior when replacing a list (i.e. going from a non-empty dataset to
+   * another non-empty dataset). This covers each dataset update after the initial one.
+   *
+   * If set to [Sync], a call to [Recycler.update] will update the recycler view (send adapter
+   * notifications) in the same call without posting / using coroutines.
+   *
+   * If set to [Async], a call to [Recycler.update] will process dataset changes in the background
+   * using coroutines and post recycler view updates to the UI thread.
+   *
+   * [Async] incurs a 1-frame penalty when updating the list, so consider your use case and the size
+   * of your dataset when choosing your [UpdateMode]. For smaller datasets, [Sync] may be preferable
+   * but for very large datasets [Async] is generally recommended.
+   *
+   * If no [itemComparator] is provided in your [Recycler.Config], dataset updates will always be
+   * processed synchronously.
+   *
+   * Set to [Async] by default as, depending on the usage, calls to update might happen when the
+   * recycler view is scrolling or laying out and recycler view throws an exception (and this
+   * library cannot find out). Its use however is encouraged provided no calls to update are
+   * triggered inside an onScrollChanged or a relayout pending (when showing/hiding a keyboard for
+   * instance).
+   */
+  var replaceMode: UpdateMode = Async
 
   // New values, initialized to the old ones.
   var data by Delegates.observable<DataSource<I>>(
@@ -67,8 +108,6 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
   var detectMoves: Boolean = true
 
   private val addedChunks = mutableListOf<List<I>>()
-  private val dataReplaced get() = oldRecyclerData.data != data
-  private val dataAdded get() = !dataReplaced && addedChunks.isNotEmpty()
   private val newData get() = data
 
   constructor(otherUpdate: Update<I>) : this(otherUpdate.oldRecyclerData) {
@@ -98,17 +137,18 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
   }
 
   /**
-   * Result object for [generateUpdateWork]. It contains:
-   * @param asyncWork List of lambdas to be executed asynchronously (can be empty).
+   * Result object for [generateDiffWork]. It contains:
+   * @param isSynchronous whether [work] should be executed on the UI thread
+   * @param updateType [UpdateType] for this work
+   * @param work List of lambdas that will calculate item diffs.
    * @param notifications List of lambdas receiving the adapter that will notify of the changes.
    */
   internal class UpdateWork(
-    private val allowSynchronousUpdate: Boolean,
-    val asyncWork: List<() -> Unit>,
+    val isSynchronous: Boolean,
+    val updateType: UpdateType,
+    val work: List<() -> Unit>,
     val notifications: List<(Adapter<*>) -> Unit>
-  ) {
-    fun isSynchronous(): Boolean = allowSynchronousUpdate && asyncWork.isEmpty()
-  }
+  )
 
   /**
    * Calculates the work needed to apply this update. It will return a
@@ -117,49 +157,80 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
    * on the main thread. This allows the caller (see [Recycler.update]) to decide if it needs to
    * go async (and missing a couple of frames) or it can be applied at once.
    */
+  @SuppressLint("NotifyDataSetChanged")
   internal fun generateUpdateWork(itemComparator: ItemComparator<I>?): UpdateWork {
-
     val extraItemChanged = oldRecyclerData.extraItem != extraItem
-    val refreshAllNeeded = dataReplaced && itemComparator == null
 
-    val asyncWork = mutableListOf<() -> Unit>()
+    val work = mutableListOf<() -> Unit>()
     val notifications = mutableListOf<(Adapter<*>) -> Unit>()
 
-    if (refreshAllNeeded) {
-      @SuppressLint("NotifyDataSetChanged")
-      notifications += { adapter -> adapter.notifyDataSetChanged() }
-    } else {
+    val updateType = when {
+      oldRecyclerData.data.isEmpty && !data.isEmpty -> Populating
+      oldRecyclerData.data != data -> Replacing
+      addedChunks.isNotEmpty() -> Adding
+      else -> NoOp
+    }
 
-      if (extraItemChanged) {
-        // We notify first the extraItem change, so we use its position in oldRecyclerData.
-        notifications += notifyChangesExtraItem()
+    lateinit var updateMode: UpdateMode
+    when (updateType) {
+      is NoOp -> return UpdateWork(
+          isSynchronous = true,
+          updateType = updateType,
+          work = emptyList(),
+          notifications = emptyList()
+      )
+      is Populating -> {
+        updateMode = populateMode
+        notifications += { adapter -> adapter.notifyItemRangeInserted(0, data.size) }
       }
+      is Replacing -> {
+        updateMode = replaceMode
 
-      when {
-        dataReplaced -> {
-          // refreshAllNeeded == false => itemComparator != null. We are going async.
-          lateinit var diffResult: DiffResult
-          asyncWork += {
-            diffResult = calculateDataChanges(itemComparator!!)
+        if (itemComparator == null) {
+          notifications.add { adapter -> adapter.notifyDataSetChanged() }
+        } else {
+          if (extraItemChanged) {
+            // We notify first the extraItem change, so we use its position in oldRecyclerData.
+            notifications += notifyChangesExtraItem()
           }
-          notifications += { adapter -> diffResult.dispatchUpdatesTo(adapter) }
+
+          with(generateDiffWork(itemComparator)) {
+            work.add(diffing)
+            notifications.add(notifying)
+          }
         }
-        dataAdded -> {
-          notifications += { adapter ->
-            val positionAt = oldRecyclerData.data.size
-            val count = addedChunks.asSequence()
+      }
+      is Adding -> {
+        updateMode = Async
+
+        notifications += { adapter ->
+          val positionAt = oldRecyclerData.data.size
+          val count = addedChunks.asSequence()
               .map(List<I>::size)
               .sum()
-            adapter.notifyItemRangeInserted(positionAt, count)
-          }
+          adapter.notifyItemRangeInserted(positionAt, count)
         }
       }
     }
 
     return UpdateWork(
-        allowSynchronousUpdate = allowSynchronousUpdate,
-        asyncWork = asyncWork,
-        notifications = notifications
+        work = work,
+        notifications = notifications,
+        updateType = updateType,
+        isSynchronous = updateMode is Sync
+    )
+  }
+
+  /**
+   * Creates the diffing and notifying lambdas for [UpdateType.Replacing] operations.
+   */
+  internal fun generateDiffWork(
+    itemComparator: ItemComparator<I>
+  ): DiffWork {
+    lateinit var diffResult: DiffResult
+    return DiffWork(
+      diffing = { diffResult = calculateDataChanges(itemComparator) },
+      notifying = { adapter -> diffResult.dispatchUpdatesTo(adapter) }
     )
   }
 
@@ -192,9 +263,9 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
    * Creates the new RecyclerData.
    * We understand the updates so we can properly build the new data source and extra item.
    */
-  fun createNewRecyclerData(config: Config<I>): RecyclerData<I> {
+  fun createNewRecyclerData(config: Config<I>, updateType: UpdateType): RecyclerData<I> {
     val newData = when {
-      dataAdded -> concatenateAddedChunks()
+      updateType is Adding -> concatenateAddedChunks()
       else -> data
     }
     return RecyclerData(config, newData, extraItem)
@@ -212,4 +283,44 @@ class Update<I : Any>(private val oldRecyclerData: RecyclerData<I>) {
     addAll((0 until data.size).asSequence().map(data::get))
     addAll(addedChunks.asSequence().flatten())
   }.toDataSource()
+
+  /**
+   * Determines whether dataset diffing happens on a background thread or on the UI thread. For
+   * large datasets, [Async] is recommended but it incurs a 1 frame penalty when dispatching the
+   * updates. For smaller datasets, [Sync] will dispatch updates immediately and avoid the 1 frame
+   * penalty.
+   */
+  sealed class UpdateMode {
+    object Async : UpdateMode()
+    object Sync : UpdateMode()
+  }
+
+  sealed class UpdateType {
+    /**
+     * Used when we're replacing an empty dataset with a non-empty dataset. Since the existing
+     * dataset is empty, we know that there's no diffing that needs to be done.
+     */
+    object Populating : UpdateType()
+
+    /**
+     * Used when we're replacing a non-empty dataset with any other dataset (even an empty one).
+     * We may need to do some diffing if an [ItemComparator] has been provided.
+     */
+    object Replacing : UpdateType()
+
+    /**
+     * Used when we're appending items to the end of the dataset.
+     */
+    object Adding : UpdateType()
+
+    /**
+     * Used when there's no change to the data,
+     */
+    object NoOp : UpdateType()
+  }
+
+  internal data class DiffWork(
+    val diffing: (() -> Unit),
+    val notifying: (Adapter<*>) -> Unit
+  )
 }


### PR DESCRIPTION
- Adds `populateMode: UpdateMode` and `replaceMode: UpdateMode` to `Update` so that we can specify whether to calculate and dispatch updates to the adapter on the UI thread or in the background via Coroutines.
- `populateMode` controls which strategy is used when adding items to the adapter for the first time, this is analogous to `allowSynchronousUpdates` (which is removed by this PR). `UpdateMode.Sync` should generally be used for `populateMode` but some things depend on the behavior we had before Cycler 0.1.11 so we need the ability to specify `UpdateMode.Async`.
- `replaceMode` controls which strategy is used when replacing the adapter's dataset. Today we always diff the data in the background and then dispatch the updates on the UI thread, incurring a 1-frame penalty even for trivial diffs. This has the advantage of avoiding dropped frames when handling large datasets but for smaller datasets and certain use cases it's not worth paying this 1-frame penalty. 